### PR TITLE
Terms deprecated

### DIFF
--- a/cdno.owl
+++ b/cdno.owl
@@ -9676,18 +9676,18 @@ SubClassOf(obo:CDNO_0200560 ObjectSomeValuesFrom(obo:RO_0000052 ObjectIntersecti
 # Class: obo:CDNO_0200561 (obsolete concentration of sodium chloride in material entity)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CDNO_0200561 "OBSOLETE. The concentration of sodium chloride when measured in some material entity."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000231 obo:CDNO_0200561 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(obo:IAO_0100001 obo:CDNO_0200561 obo:CDNO_0200176)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CDNO_0200561 "material entity sodium chloride concentration"^^xsd:string)
-AnnotationAssertion(rdfs:comment obo:CDNO_0200561 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CDNO_0200561 "obsolete concentration of sodium chloride in material entity"^^xsd:string)
 AnnotationAssertion(owl:deprecated obo:CDNO_0200561 "true"^^xsd:boolean)
 
 # Class: obo:CDNO_0200562 (obsolete concentration of calcium dichloride in material entity)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CDNO_0200562 "OBSOLETE. The concentration of calcium dichloride when measured in some material entity."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000231 obo:CDNO_0200562 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(obo:IAO_0100001 obo:CDNO_0200562 obo:CDNO_0200546)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CDNO_0200562 "material entity calcium dichloride concentration"^^xsd:string)
-AnnotationAssertion(rdfs:comment obo:CDNO_0200562 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CDNO_0200562 "obsolete concentration of calcium dichloride in material entity"^^xsd:string)
 AnnotationAssertion(owl:deprecated obo:CDNO_0200562 "true"^^xsd:boolean)
 
@@ -9777,9 +9777,9 @@ SubClassOf(obo:CDNO_0200571 ObjectSomeValuesFrom(obo:RO_0000052 ObjectIntersecti
 # Class: obo:CDNO_0200572 (obsolete concentration of magnesium dichloride in material entity)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CDNO_0200572 "OBSOLETE. The concentration of magnesium dichloride when measured in some material entity."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000231 obo:CDNO_0200572 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(obo:IAO_0100001 obo:CDNO_0200572 obo:CDNO_0200563)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CDNO_0200572 "material entity magnesium dichloride concentration"^^xsd:string)
-AnnotationAssertion(rdfs:comment obo:CDNO_0200572 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CDNO_0200572 "obsolete concentration of magnesium dichloride in material entity"^^xsd:string)
 AnnotationAssertion(owl:deprecated obo:CDNO_0200572 "true"^^xsd:boolean)
 
@@ -9907,36 +9907,36 @@ SubClassOf(obo:CDNO_0200585 ObjectSomeValuesFrom(obo:RO_0000052 ObjectIntersecti
 # Class: obo:CDNO_0200586 (obsolete concentration of lysophosphatidylcholine in material entity)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CDNO_0200586 "OBSOLETE. The concentration of lysophosphatidylcholine when measured in some material entity."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000231 obo:CDNO_0200586 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(obo:IAO_0100001 obo:CDNO_0200586 obo:CDNO_0200118)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CDNO_0200586 "material entity lysophosphatidylcholine concentration"^^xsd:string)
-AnnotationAssertion(rdfs:comment obo:CDNO_0200586 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CDNO_0200586 "obsolete concentration of lysophosphatidylcholine in material entity"^^xsd:string)
 AnnotationAssertion(owl:deprecated obo:CDNO_0200586 "true"^^xsd:boolean)
 
 # Class: obo:CDNO_0200587 (obsolete concentration of phosphatidylcholine in material entity)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CDNO_0200587 "OBSOLETE. The concentration of phosphatidylcholine when measured in some material entity."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000231 obo:CDNO_0200587 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(obo:IAO_0100001 obo:CDNO_0200587 obo:CDNO_0200114)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CDNO_0200587 "material entity phosphatidylcholine concentration"^^xsd:string)
-AnnotationAssertion(rdfs:comment obo:CDNO_0200587 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CDNO_0200587 "obsolete concentration of phosphatidylcholine in material entity"^^xsd:string)
 AnnotationAssertion(owl:deprecated obo:CDNO_0200587 "true"^^xsd:boolean)
 
 # Class: obo:CDNO_0200588 (obsolete concentration of phosphatidylethanolamine in material entity)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CDNO_0200588 "OBSOLETE. The concentration of phosphatidylethanolamine when measured in some material entity."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000231 obo:CDNO_0200588 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(obo:IAO_0100001 obo:CDNO_0200588 obo:CDNO_0200115)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CDNO_0200588 "material entity phosphatidylethanolamine concentration"^^xsd:string)
-AnnotationAssertion(rdfs:comment obo:CDNO_0200588 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CDNO_0200588 "obsolete concentration of phosphatidylethanolamine in material entity"^^xsd:string)
 AnnotationAssertion(owl:deprecated obo:CDNO_0200588 "true"^^xsd:boolean)
 
 # Class: obo:CDNO_0200589 (obsolete concentration of phosphatidylinositol in material entity)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CDNO_0200589 "OBSOLETE. The concentration of phosphatidylinositol when measured in some material entity."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000231 obo:CDNO_0200589 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(obo:IAO_0100001 obo:CDNO_0200589 obo:CDNO_0200117)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CDNO_0200589 "material entity phosphatidylinositol concentration"^^xsd:string)
-AnnotationAssertion(rdfs:comment obo:CDNO_0200589 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CDNO_0200589 "obsolete concentration of phosphatidylinositol in material entity"^^xsd:string)
 AnnotationAssertion(owl:deprecated obo:CDNO_0200589 "true"^^xsd:boolean)
 
@@ -9952,9 +9952,9 @@ SubClassOf(obo:CDNO_0200590 ObjectSomeValuesFrom(obo:RO_0000052 ObjectIntersecti
 # Class: obo:CDNO_0200591 (obsolete concentration of myo-inositol hexakisphosphate in material entity)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CDNO_0200591 "OBSOLETE. The concentration of myo-inositol hexakisphosphate when measured in some material entity."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000231 obo:CDNO_0200591 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(obo:IAO_0100001 obo:CDNO_0200591 obo:CDNO_0200433)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CDNO_0200591 "material entity myo-inositol hexakisphosphate concentration"^^xsd:string)
-AnnotationAssertion(rdfs:comment obo:CDNO_0200591 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CDNO_0200591 "obsolete concentration of myo-inositol hexakisphosphate in material entity"^^xsd:string)
 AnnotationAssertion(owl:deprecated obo:CDNO_0200591 "true"^^xsd:boolean)
 
@@ -9979,9 +9979,9 @@ SubClassOf(obo:CDNO_0200593 ObjectSomeValuesFrom(obo:RO_0000052 ObjectIntersecti
 # Class: obo:CDNO_0200594 (obsolete concentration of potassium chloride in material entity)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CDNO_0200594 "OBSOLETE. The concentration of potassium chloride when measured in some material entity."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000231 obo:CDNO_0200594 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(obo:IAO_0100001 obo:CDNO_0200594 obo:CDNO_0200564)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CDNO_0200594 "material entity potassium chloride concentration"^^xsd:string)
-AnnotationAssertion(rdfs:comment obo:CDNO_0200594 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CDNO_0200594 "obsolete concentration of potassium chloride in material entity"^^xsd:string)
 AnnotationAssertion(owl:deprecated obo:CDNO_0200594 "true"^^xsd:boolean)
 
@@ -10043,9 +10043,9 @@ SubClassOf(obo:CDNO_0200600 ObjectSomeValuesFrom(obo:RO_0000052 ObjectIntersecti
 # Class: obo:CDNO_0200601 (obsolete concentration of sodium chloride in material entity)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CDNO_0200601 "OBSOLETE. The concentration of sodium chloride when measured in some material entity."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000231 obo:CDNO_0200601 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(obo:IAO_0100001 obo:CDNO_0200601 obo:CDNO_0200176)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CDNO_0200601 "material entity sodium chloride concentration"^^xsd:string)
-AnnotationAssertion(rdfs:comment obo:CDNO_0200601 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CDNO_0200601 "obsolete concentration of sodium chloride in material entity"^^xsd:string)
 AnnotationAssertion(owl:deprecated obo:CDNO_0200601 "true"^^xsd:boolean)
 
@@ -10252,9 +10252,9 @@ SubClassOf(obo:CDNO_0200623 ObjectSomeValuesFrom(obo:RO_0000052 ObjectIntersecti
 # Class: obo:CDNO_0200624 (obsolete concentration of sodium hydrogensulfite in material entity)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CDNO_0200624 "OBSOLETE. The concentration of sodium hydrogensulfite when measured in some material entity."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000231 obo:CDNO_0200624 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(obo:IAO_0100001 obo:CDNO_0200624 obo:CDNO_0200604)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CDNO_0200624 "material entity sodium hydrogensulfite concentration"^^xsd:string)
-AnnotationAssertion(rdfs:comment obo:CDNO_0200624 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CDNO_0200624 "obsolete concentration of sodium hydrogensulfite in material entity"^^xsd:string)
 AnnotationAssertion(owl:deprecated obo:CDNO_0200624 "true"^^xsd:boolean)
 
@@ -10325,18 +10325,18 @@ SubClassOf(obo:CDNO_0200631 ObjectSomeValuesFrom(obo:RO_0000052 ObjectIntersecti
 # Class: obo:CDNO_0200632 (obsolete concentration of cysteine in material entity)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CDNO_0200632 "OBSOLETE. The concentration of cysteine when measured in some material entity."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000231 obo:CDNO_0200632 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(obo:IAO_0100001 obo:CDNO_0200632 obo:CDNO_0200051)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CDNO_0200632 "material entity cysteine concentration"^^xsd:string)
-AnnotationAssertion(rdfs:comment obo:CDNO_0200632 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CDNO_0200632 "obsolete concentration of cysteine in material entity"^^xsd:string)
 AnnotationAssertion(owl:deprecated obo:CDNO_0200632 "true"^^xsd:boolean)
 
 # Class: obo:CDNO_0200633 (obsolete concentration of methionine in material entity)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CDNO_0200633 "OBSOLETE. The concentration of methionine when measured in some material entity."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000231 obo:CDNO_0200633 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(obo:IAO_0100001 obo:CDNO_0200633 obo:CDNO_0200060)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CDNO_0200633 "material entity methionine concentration"^^xsd:string)
-AnnotationAssertion(rdfs:comment obo:CDNO_0200633 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CDNO_0200633 "obsolete concentration of methionine in material entity"^^xsd:string)
 AnnotationAssertion(owl:deprecated obo:CDNO_0200633 "true"^^xsd:boolean)
 
@@ -10514,9 +10514,9 @@ SubClassOf(obo:CDNO_0200652 ObjectSomeValuesFrom(obo:RO_0000052 ObjectIntersecti
 # Class: obo:CDNO_0200653 (obsolete concentration of iron(2+) sulfate (anhydrous) in material entity)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CDNO_0200653 "OBSOLETE. The concentration of iron(2+) sulfate (anhydrous) when measured in some material entity."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000231 obo:CDNO_0200653 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(obo:IAO_0100001 obo:CDNO_0200653 obo:CDNO_0200623)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CDNO_0200653 "material entity iron(2+) sulfate (anhydrous) concentration"^^xsd:string)
-AnnotationAssertion(rdfs:comment obo:CDNO_0200653 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CDNO_0200653 "obsolete concentration of iron(2+) sulfate (anhydrous) in material entity"^^xsd:string)
 AnnotationAssertion(owl:deprecated obo:CDNO_0200653 "true"^^xsd:boolean)
 
@@ -10987,10 +10987,10 @@ SubClassOf(obo:CDNO_0200704 ObjectSomeValuesFrom(obo:RO_0000052 ObjectIntersecti
 # Class: obo:CDNO_0200705 (obsolete concentration of polyol in material entity)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CDNO_0200705 "OBSOLETE. The concentration of polyol when measured in some material entity."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000231 obo:CDNO_0200705 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(obo:IAO_0100001 obo:CDNO_0200705 obo:CDNO_0200444)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CDNO_0200705 "INFOODs: POLYL"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CDNO_0200705 "material entity polyol concentration"^^xsd:string)
-AnnotationAssertion(rdfs:comment obo:CDNO_0200705 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CDNO_0200705 "obsolete concentration of polyol in material entity"^^xsd:string)
 AnnotationAssertion(owl:deprecated obo:CDNO_0200705 "true"^^xsd:boolean)
 
@@ -11008,39 +11008,39 @@ SubClassOf(obo:CDNO_0200706 ObjectSomeValuesFrom(obo:RO_0000052 ObjectIntersecti
 # Class: obo:CDNO_0200707 (obsolete concentration of mannitol in material entity)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CDNO_0200707 "OBSOLETE. The concentration of mannitol when measured in some material entity."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000231 obo:CDNO_0200707 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(obo:IAO_0100001 obo:CDNO_0200707 obo:CDNO_0200445)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CDNO_0200707 "INFOODs: MANTL"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CDNO_0200707 "material entity mannitol concentration"^^xsd:string)
-AnnotationAssertion(rdfs:comment obo:CDNO_0200707 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CDNO_0200707 "obsolete concentration of mannitol in material entity"^^xsd:string)
 AnnotationAssertion(owl:deprecated obo:CDNO_0200707 "true"^^xsd:boolean)
 
 # Class: obo:CDNO_0200708 (obsolete concentration of glycerol in material entity)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CDNO_0200708 "OBSOLETE. The concentration of glycerol when measured in some material entity."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000231 obo:CDNO_0200708 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(obo:IAO_0100001 obo:CDNO_0200708 obo:CDNO_0200451)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CDNO_0200708 "INFOODs: GLYRL"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CDNO_0200708 "material entity glycerol concentration"^^xsd:string)
-AnnotationAssertion(rdfs:comment obo:CDNO_0200708 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CDNO_0200708 "obsolete concentration of glycerol in material entity"^^xsd:string)
 AnnotationAssertion(owl:deprecated obo:CDNO_0200708 "true"^^xsd:boolean)
 
 # Class: obo:CDNO_0200709 (obsolete concentration of glucitol in material entity)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CDNO_0200709 "OBSOLETE. The concentration of glucitol when measured in some material entity."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000231 obo:CDNO_0200709 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(obo:IAO_0100001 obo:CDNO_0200709 obo:CDNO_0200447)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CDNO_0200709 "material entity glucitol concentration"^^xsd:string)
-AnnotationAssertion(rdfs:comment obo:CDNO_0200709 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CDNO_0200709 "obsolete concentration of glucitol in material entity"^^xsd:string)
 AnnotationAssertion(owl:deprecated obo:CDNO_0200709 "true"^^xsd:boolean)
 
 # Class: obo:CDNO_0200710 (obsolete concentration of xylitol in material entity)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CDNO_0200710 "OBSOLETE. The concentration of xylitol when measured in some material entity."^^xsd:string)
+AnnotationAssertion(obo:IAO_0000231 obo:CDNO_0200710 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(obo:IAO_0100001 obo:CDNO_0200710 obo:CDNO_0200446)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CDNO_0200710 "INFOODs: XYLTL"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CDNO_0200710 "material entity xylitol concentration"^^xsd:string)
-AnnotationAssertion(rdfs:comment obo:CDNO_0200710 "The equivalency statement has been duplicated"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CDNO_0200710 "obsolete concentration of xylitol in material entity"^^xsd:string)
 AnnotationAssertion(owl:deprecated obo:CDNO_0200710 "true"^^xsd:boolean)
 
@@ -11373,7 +11373,7 @@ AnnotationAssertion(rdfs:label obo:CHEBI_131693 "7,10,13,16-docosatetraenoic aci
 AnnotationAssertion(rdfs:label obo:CHEBI_131693 "7,10,13,16-docosatetraenoic acid"@en)
 SubClassOf(obo:CHEBI_131693 obo:CHEBI_36009)
 
-# Class: obo:CHEBI_132141 (1,2-napthoquinone)
+# Class: obo:CHEBI_132141 (1,2-naphthoquinones)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CHEBI_132141 "Any napthoquinone in which the oxo groups of the quinone moiety are at the 1 and 2 positions of the naphthalene ring.")
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CHEBI_132141 "chebi_ontology")


### PR DESCRIPTION
I have deprecated terms that were duplicated according to issue #101 

To do this task I followed an [ODK workflow](https://ontology-development-kit.readthedocs.io/_/downloads/en/latest/pdf/)
Here are the terms that have been deprecated:


<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:w="urn:schemas-microsoft-com:office:word"
xmlns:m="http://schemas.microsoft.com/office/2004/12/omml"
xmlns="http://www.w3.org/TR/REC-html40">

CDNO:0200561 | CHEBI:26710 | sodium chloride
-- | -- | --
CDNO:0200562 | CHEBI:3312 | calcium dichloride
CDNO:0200572 | CHEBI:6636 | magnesium dichloride
CDNO:0200586 | CHEBI:60479 | lysophosphatidylcholine
CDNO:0200587 | CHEBI:64482 | phosphatidylcholine
CDNO:0200588 | CHEBI:16038 | phosphatidylethanolamine
CDNO:0200589 | CHEBI:28874 | phosphatidylinositol
CDNO:0200591 | CHEBI:17401 | myo-inositol hexakisphosphate
CDNO:0200594 | CHEBI:32588 | potassium chloride
CDNO:0200601 | CHEBI:26710 | sodium chloride
CDNO:0200624 | CHEBI:26709 | sodium hydrogensulfite
CDNO:0200632 | CHEBI:15356 | cysteine
CDNO:0200633 | CHEBI:16811 | methionine
CDNO:0200705 | CHEBI:26191 | polyol
CDNO:0200707 | CHEBI:29864 | mannitol
CDNO:0200708 | CHEBI:17754 | glycerol
CDNO:0200709 | CHEBI:30911 | glucitol
CDNO:0200710 | CHEBI:17151 | xylitol
